### PR TITLE
Fix ArgumentNullException in VideoIndexer 

### DIFF
--- a/Crawl/VideoIndexer/VideoIndexer.cs
+++ b/Crawl/VideoIndexer/VideoIndexer.cs
@@ -178,7 +178,7 @@ namespace Microsoft.DecisionService.Crawl
                     // The GetVideoIndexerBreakdownAsync call can, if the underlying call to VideoIndexer GetBreakdown fails - but the 
                     // call to VideoIndexer SearchBreakdown succeeds, return a BlobContent with an empty Value, and a short "expires".
                     // Treat that as the same as not getting a VideoIndexer response.
-                    if (breakdownContent == null || String.IsNullOrWhiteSpace(breakdownContent.Value))
+                    if (breakdownContent == null || string.IsNullOrWhiteSpace(breakdownContent.Value))
                     {
                         if (string.IsNullOrEmpty(reqBody.Video))
                         {


### PR DESCRIPTION
This happens when the VideoIndexer service knows about a video (the breakdown search call succeeds), but the get breakdown call fails, e.g. HTTP 429: Too many requests.

Also avoid queueing indexing when the video URL is not a valid URL.