### PR TITLE
Crawler pipeline hardening

### DIFF
--- a/Crawl/Crawl/Crawl.cs
+++ b/Crawl/Crawl/Crawl.cs
@@ -117,6 +117,27 @@ namespace Microsoft.DecisionService.Crawl
                 catch (WebException we)
                 {
                     HttpWebResponse httpResponse = we.Response as HttpWebResponse;
+                    if (we.Status == WebExceptionStatus.ServerProtocolViolation)
+                    {
+                        // Get a little more telemetry about what is going on here.
+                        IDictionary<string, string> traceData = new Dictionary<string, string>();
+                        traceData["Response.SupportsHeaders"] = we.Response.SupportsHeaders.ToString();
+
+                        for (int i = 0; i < we.Response.Headers.Count; i++)
+                        {
+                            string headerName = we.Response.Headers.GetKey(i);
+                            string headerValue = we.Response.Headers.Get(i);
+                            traceData[$"Response.Headers.{headerName}"] = headerValue;
+                        }
+
+                        if (httpResponse != null)
+                        {
+                            traceData["HttpResponse.StatusCode"] = httpResponse.StatusCode.ToString();
+                        }
+
+                        Services.TelemetryClient.TrackTrace($"Download target ({uri}) ServerProtocolViolation", SeverityLevel.Error, traceData);
+                    }
+
                     if (httpResponse != null)
                     {
                         // Ignore known cases where crawl fails due to error on the crawl-target side - these should not

--- a/Crawl/Crawl/Crawl.cs
+++ b/Crawl/Crawl/Crawl.cs
@@ -116,8 +116,18 @@ namespace Microsoft.DecisionService.Crawl
                 }
                 catch (WebException we)
                 {
-                    if ((we.Response as HttpWebResponse)?.StatusCode == HttpStatusCode.Forbidden)
-                        continue;
+                    HttpWebResponse httpResponse = we.Response as HttpWebResponse;
+                    if (httpResponse != null)
+                    {
+                        // Ignore known cases where crawl fails due to error on the crawl-target side - these should not
+                        // cause a hard failure on our end.
+                        if (httpResponse.StatusCode == HttpStatusCode.Forbidden ||
+                            httpResponse.StatusCode == HttpStatusCode.NotFound ||
+                            httpResponse.StatusCode == HttpStatusCode.ServiceUnavailable)
+                        {
+                            continue;
+                        }
+                    }
 
                     throw;
                 }

--- a/Crawl/Crawl/Crawl.cs
+++ b/Crawl/Crawl/Crawl.cs
@@ -117,17 +117,22 @@ namespace Microsoft.DecisionService.Crawl
                 catch (WebException we)
                 {
                     HttpWebResponse httpResponse = we.Response as HttpWebResponse;
-                    if (we.Status == WebExceptionStatus.ServerProtocolViolation)
+                    if (we.Status == WebExceptionStatus.ServerProtocolViolation && we.Response != null)
                     {
                         // Get a little more telemetry about what is going on here.
-                        IDictionary<string, string> traceData = new Dictionary<string, string>();
-                        traceData["Response.SupportsHeaders"] = we.Response.SupportsHeaders.ToString();
-
-                        for (int i = 0; i < we.Response.Headers.Count; i++)
+                        IDictionary<string, string> traceData = new Dictionary<string, string>()
                         {
-                            string headerName = we.Response.Headers.GetKey(i);
-                            string headerValue = we.Response.Headers.Get(i);
-                            traceData[$"Response.Headers.{headerName}"] = headerValue;
+                            { "Response.SupportsHeaders", we.Response.SupportsHeaders.ToString() }
+                        };
+
+                        if (we.Response.SupportsHeaders)
+                        {
+                            for (int i = 0; i < we.Response.Headers.Count; i++)
+                            {
+                                string headerName = we.Response.Headers.GetKey(i);
+                                string headerValue = we.Response.Headers.Get(i);
+                                traceData[$"Response.Headers.{headerName}"] = headerValue;
+                            }
                         }
 
                         if (httpResponse != null)


### PR DESCRIPTION
The crawler pipeline errors out and 500s, logging failed operations and exceptions during regular operation (e.g. when the underlying url is missing, or due to a transient failure at the target host). There is already a pattern for silently dealing with these failures - this is desirable as it reduces the noise in monitoring.

This change extends this pattern to underlying 404s and 503s, as well as adding additional telemetry when the target server responds in a way that triggers ServerProtocolViolation.
