### PR TITLE
RankRewardAnalyzer.py: Fixes and improvements

### DIFF
--- a/DataScience/AzureStorageDownloader.py
+++ b/DataScience/AzureStorageDownloader.py
@@ -53,6 +53,7 @@ def update_progress(current, total):
 
 def download_container(container, log_dir, start_date=None, end_date=None, overwrite_mode=0, dry_run=False, version=2, auth_fp=None, output_fp='', verbose=False):
     
+    t_start = time.time()
     print('-----'*10)
     print('Current UTC time: {}'.format(datetime.datetime.now(datetime.timezone.utc)))
     print('Start Date: {}'.format(start_date))
@@ -153,7 +154,8 @@ def download_container(container, log_dir, start_date=None, end_date=None, overw
                     print('\nDownloaded {:.3f} MB in {:.3f} sec.: Average: {:.3f} MB/sec'.format(file_size, elapsed_time, file_size/elapsed_time))
             except Exception as e:
                 print(' Error: {}'.format(e))
-            
+    print('Total download time:',time.time()-t_start)
+
 
 if __name__ == '__main__':
     
@@ -163,6 +165,4 @@ if __name__ == '__main__':
     
     ################################# PARSE INPUT CMD #########################################################
     
-    t0 = time.time()
     download_container(**kwargs)
-    print('Total download time:',time.time()-t0)

--- a/DataScience/RankRewardAnalyzer.py
+++ b/DataScience/RankRewardAnalyzer.py
@@ -1,5 +1,14 @@
-import requests, time, json, os, argparse, sys
+import requests, time, json, os, argparse, sys, collections
+import matplotlib.pyplot as plt
 
+
+def scantree(path):
+    """Recursively yield DirEntry objects for given directory."""
+    for entry in os.scandir(path):
+        if entry.is_dir(follow_symlinks=False):
+            yield from scantree(entry.path)
+        else:
+            yield entry
 
 def update_progress(current, total, display=''):
     barLength = 50 # Length of the progress bar
@@ -8,8 +17,17 @@ def update_progress(current, total, display=''):
     text = "\rProgress: [{}] {:.1f}% - Iter: {}/{} - {}".format( "#"*block + "-"*(barLength-block), progress*100,current,total,display)
     sys.stdout.write(text)
     sys.stdout.flush()
+    
+def dup_analysis(log_list):
+    c = collections.Counter(y[0] for y in log_list)
+    data = {}
+    for i,x in enumerate(log_list):
+        if c[x[0]] > 1:
+            data.setdefault(x[0], []).append((i,x[1]))
+    for x in data:
+        print(x, data[x])
 
-def send_rank_and_rewards(base_url, app, local_fp, feed, iter_num=1000, time_sleep=0.05):
+def send_rank_and_rewards(base_url, app, local_fp, feed, iter_num=1000, time_sleep=0.05, verbose=False):
 
     print('Sending rank/reward requests...')
 
@@ -28,35 +46,49 @@ def send_rank_and_rewards(base_url, app, local_fp, feed, iter_num=1000, time_sle
         err = [0,0]
         for i in range(1,iter_num+1):
             r = s.get(rank_url)
-            f.write('url:{}\tstatus_code:{}\theaders:{}\tcontent:{}\n'.format(rank_url,r.status_code,r.headers['x-msdecision-src'],r.content))
-            if r.status_code != 200 or r.headers['x-msdecision-src'] != site_str or b'rewardAction' not in r.content:
+            f.write('url:{}\tstatus_code:{}\theaders:{}\tcontent:{}\n'.format(rank_url,r.status_code,r.headers,r.content))
+            if r.status_code != 200 or r.headers.get('x-msdecision-src', None) != site_str or b'rewardAction' not in r.content:
                 err[0] += 1
-                print('Rank Error - status_code: {}; headers: {}; content: {}',r.status_code,r.headers['x-msdecision-src'],r.content)
+                print('Rank Error - status_code: {}; headers: {}; content: {}'.format(r.status_code,r.headers,r.content))
                 continue
             eventId = str(r.content.split(b'eventId":"',1)[1].split(b'","',1)[0], 'utf-8')
             eventIds.append(eventId)
             r2 = s.post(url+'/reward/'+eventId, json=i+.18)
-            f.write('url:{}\tstatus_code:{}\theaders:{}\tcontent:{}\n'.format(url+'/reward/'+eventId,r2.status_code,r2.headers['x-msdecision-src'],i+.18))
-            if r2.status_code != 200 or r2.headers['X-MSDecision-Src'] != site_str:
+            f.write('url:{}\tstatus_code:{}\theaders:{}\tcontent:{}\n'.format(url+'/reward/'+eventId,r2.status_code,r2.headers,i+.18))
+            if r2.status_code != 200 or r2.headers.get('x-msdecision-src', None) != site_str:
                 err[1] += 1
-                print('Reward Error - status_code: {}; headers: {}',r2.status_code,r2.headers['x-msdecision-src'])
+                print('Reward Error - status_code: {}; headers: {}'.format(r2.status_code,r2.headers))
             
             update_progress(i, iter_num, 'Errors: {}'.format(err))
             time.sleep(time_sleep)
             
     return eventIds
 
-def print_stats(local_fp, azure_path):
+def print_stats(local_fp, azure_path, verbose=False, plot_hist=False):
 
     print('Computing statistics...')
 
-    local_rank = [x.strip().split('"eventId":"',1)[1].split('","',1)[0] for x in open(local_fp, encoding='utf-8') if '/rank/' in x]
-    local_rew = [(x.strip().split('/reward/',1)[1].split('\t',1)[0],x.strip().split('content:',1)[1]) for x in open(local_fp, encoding='utf-8') if '/reward/' in x]
+    local_rank = []
+    local_rew = []
+    lines_errs = 0
+    err_codes = collections.Counter()
+    for x in open(local_fp, encoding='utf-8'):
+        if 'status_code:200' in x:
+            if '/rank/' in x and '"eventId":"' in x:
+                local_rank.append(x.split('"eventId":"',1)[1].split('","',1)[0])
+            elif '/reward/' in x and 'content:' in x:
+                local_rew.append((x.split('/reward/',1)[1].split('\t',1)[0], x.strip().split('content:',1)[1]))
+            else:
+                lines_errs += 1
+        else:
+            err_codes.update([x.split('status_code:',1)[1].split('\t',1)[0]])
+
     if os.path.isdir(azure_path):
-        azure_data = [(x.strip().split('EventId":"',1)[1].split('","',1)[0], x.strip().split('_label_cost":',1)[1].split(',"',1)[0]) for azure_fp in os.scandir(azure_path) if azure_fp.name.endswith('.json') for x in open(azure_fp.path, encoding='utf-8')]
+        azure_data = [(x.strip().split('EventId":"',1)[1].split('","',1)[0], x.strip().split('_label_cost":',1)[1].split(',"',1)[0]) for azure_fp in scantree(azure_path) if azure_fp.name.endswith('.json') for x in open(azure_fp.path, encoding='utf-8')]
     else:
         azure_data = [(x.strip().split('EventId":"',1)[1].split('","',1)[0], x.strip().split('_label_cost":',1)[1].split(',"',1)[0]) for x in open(azure_path, encoding='utf-8')]
     
+    local_rank_set = set(local_rank)
     rew_dict = {y[0] : y[1] for y in local_rew}
     azure_dict = {y[0] : y[1] for y in azure_data}
     
@@ -65,24 +97,53 @@ def print_stats(local_fp, azure_path):
     for i,x in enumerate(local_rank):
         if x in azure_dict:
             if float(rew_dict[x]) != -float(azure_dict[x]):
-                print('Idx: {} - Error in reward: Local: {} Azure: {} - EventId: {}'.format(i+1,rew_dict[x], azure_dict[x],x))
+                if verbose:
+                    print('Idx: {} - Error in reward: Local: {} Azure: {} - EventId: {}'.format(i+1,rew_dict[x], azure_dict[x],x))
                 err_rewards_idx.append(i+1)
         else:
             no_events_idx.append(i+1)
-            print('Idx: {} - Ranking missing from Azure - EventId: {}'.format(i+1,x))
+            if verbose:
+                print('Idx: {} - Ranking missing from Azure - EventId: {}'.format(i+1,x))
+
+    dup_local = len(local_rew)-len(rew_dict)
+    dup_azure = len(azure_data)-len(azure_dict)
+    if verbose:
+        print('-----'*10)
+        print('Missing events indexes (1-based indexing)\n{}'.format(no_events_idx))
+        print('-----'*10)
+        print('Wrong rewards indexes (1-based indexing)\n{}'.format(err_rewards_idx))
+        if dup_local > 0:
+            print('-----'*10)
+            print('Duplicates in Local rewards')
+            dup_analysis(local_rew)    
+        if dup_azure > 0:
+            print('-----'*10)
+            print('Duplicates in Azure Storage')
+            dup_analysis(azure_data)
     print('-----'*10)
-    print('Missing events indexes (1-based indexing)\n{}'.format(no_events_idx))
+    print('Events in local_rank: {} (Duplicates: {})'.format(len(local_rank), len(local_rank)-len(local_rank_set)))
+    print('Events in local_rew: {} (Duplicates: {})'.format(len(local_rew), dup_local))
+    print('Events in azure_data: {} (Duplicates: {})'.format(len(azure_data), dup_azure))
     print('-----'*10)
-    print('Wrong rewards indexes (1-based indexing)\n{}'.format(err_rewards_idx))
+    print('Intersection local_rank/local_rew:',len(local_rank_set.intersection(rew_dict.keys())))
+    print('Intersection local_rank/azure_data:',len(local_rank_set.intersection(azure_dict.keys())))
+    print('Missing EventIds: {}'.format(len(no_events_idx)), end='')
+    if no_events_idx:
+        print(' (oldest 1-base index: {}/{})'.format(min(no_events_idx),len(local_rank)), end='')
+    print('\nWrong rewards: {}'.format(len(err_rewards_idx)))
     print('-----'*10)
-    print('Events in local_rew: {} (Duplicates: {})'.format(len(local_rew), len(local_rew)-len(rew_dict)))
-    print('Events in local_rank: {} (Duplicates: {})'.format(len(local_rank), len(local_rank)-len(set(local_rank))))
-    print('Events in azure_data: {} (Duplicates: {})'.format(len(azure_data), len(azure_data)-len(azure_dict)))
+    print('status_codes errors: {}'.format(err_codes.most_common()))
+    print('Lines skipped in Local file: {}'.format(lines_errs))
     print('-----'*10)
-    print('Intersection local_rew/local_rank:',len(set(rew_dict.keys()).intersection(local_rank)))   
-    print('Intersection local_rew/azure_data:',len(set(rew_dict.keys()).intersection(azure_dict.keys())))
-    print('Missing EventIds: {} (oldest index: {}/{})\nWrong rewards: {}'.format(len(no_events_idx),min(no_events_idx),len(local_rank),len(err_rewards_idx)))
-    print('-----'*10)
+    if plot_hist:
+        plt.rcParams.update({'font.size': 16})  # General font size
+        plt.hist(err_rewards_idx, 1000, label='No reward', color='xkcd:orange')
+        plt.hist(no_events_idx, 1000, label='No rank', color='xkcd:blue')
+        plt.title('Missing rank and reward requests', fontsize=30)
+        plt.xlabel('Request index', fontsize=18)
+        plt.ylabel('Bin Count', fontsize=18)
+        plt.legend()
+        plt.show()
 
 
 if __name__ == '__main__':
@@ -95,13 +156,15 @@ if __name__ == '__main__':
     parser.add_argument('-f','--feed', help="feed name")
     parser.add_argument('-u','--base_url', default="https://ds.microsoft.com/api/v2/", help="base url (default: https://ds.microsoft.com/api/v2/)")
     parser.add_argument('-i','--iter_num', type=int, default=1000, help="number of requests/rewards (default: 1000)")
-    parser.add_argument('-t','--time_sleep', default=0.05, help="time_sleep between interations (default: 0.05)")
+    parser.add_argument('-t','--time_sleep', type=float, default=0.05, help="time_sleep between interations (default: 0.05)")
+    parser.add_argument('-v','--verbose', help="print eventId of missing rank and rewards", action='store_true')
+    parser.add_argument('-p','--plot_hist', help="plot hist of missing rank and rewards", action='store_true')
     
     
     kwargs = vars(parser.parse_args())
     
     if kwargs['azure_path']:
-        print_stats(kwargs['local_fp'], kwargs['azure_path'])
+        print_stats(kwargs['local_fp'], kwargs['azure_path'], kwargs['verbose'], kwargs['plot_hist'])
     else:
         if not kwargs['app']:
             print('When sending rank/reward requests, --app is required')
@@ -111,4 +174,5 @@ if __name__ == '__main__':
 
         if kwargs['feed'] and kwargs['app']:
             kwargs.pop('azure_path')
+            kwargs.pop('plot_hist')
             send_rank_and_rewards(**kwargs)


### PR DESCRIPTION
- Fixed bug when x-msdecision-src is not in header (write full header to output file)
- Fixed bug in printout when no_events_idx is empty
- Fixed bug using float for time_sleep
- Fixed bug with format in printouts
- Scan dir tree when --azure_path is a dir
- Added --verbose in print_stats
- Added printout of duplicates in --verbose
- Added --plot_hist to plot missing ranking and reward requests timeline
- Speedup