### PR TITLE
Experimentation.py: Fixed bug in auto-detect namespaces

### DIFF
--- a/DataScience/Experimentation.py
+++ b/DataScience/Experimentation.py
@@ -90,8 +90,8 @@ def detect_namespaces(j_obj, ns_set, marginal_set=None):
         key = kv_entry[0]
         value = kv_entry[1]
 
-        # Ignore entries whose key begins with an '_'
-        if key[0] == '_':
+        # Ignore entries whose key begins with an '_' except _text
+        if key[0] == '_' and key != '_text':
             continue
 
         if type(value) is list:


### PR DESCRIPTION
@eisber @sidsen Do we have other special keys other than `_text` that can be found inside `_multi` (i.e., disregarding `_label_cost`, etc.)?