### PR TITLE
Crawl Pipeline Fix

### DIFF
--- a/Crawl/CognitiveServiceEntityLinking/CognitiveServiceEntityLinking.cs
+++ b/Crawl/CognitiveServiceEntityLinking/CognitiveServiceEntityLinking.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DecisionService.Crawl
                     if (textBuilder.Length == 0)
                         return null;
 
-                    string text = Services.Limit(textBuilder.ToString(), 10240);
+                    string text = Services.Limit(textBuilder.ToString(), Constants.MaxRequestSizeAnsi);
 
                     // EntityLinking has moved under the TextAnalytics Cognitive Service, so the request body is now shaped
                     // like the TextAnalytics request

--- a/Crawl/CognitiveServiceTextAnalytics/CognitiveServiceTextAnalytics.cs
+++ b/Crawl/CognitiveServiceTextAnalytics/CognitiveServiceTextAnalytics.cs
@@ -28,7 +28,9 @@ namespace Microsoft.DecisionService.Crawl
         {
             // Based on email thread with Arvind Krishnaa Jagannathan <arjagann@microsoft.com>
             if (text.Length >= Constants.MaxRequestSizeUtf16)
-            text = text.Substring(0, Constants.MaxRequestSizeUtf16);
+            {
+                text = text.Substring(0, Constants.MaxRequestSizeUtf16);
+            }
 
             return new TextAnalyticRequest
             {
@@ -60,10 +62,6 @@ namespace Microsoft.DecisionService.Crawl
                         return null;
 
                     var text = textBuilder.ToString();
-
-                    // Based on email thread with Arvind Krishnaa Jagannathan <arjagann@microsoft.com>
-                    if (text.Length >= Constants.MaxRequestSizeUtf16)
-                        text = text.Substring(0, Constants.MaxRequestSizeUtf16);
 
                     return CreateRequestFromText(text);
                 },

--- a/Crawl/CognitiveServiceTextAnalytics/CognitiveServiceTextAnalytics.cs
+++ b/Crawl/CognitiveServiceTextAnalytics/CognitiveServiceTextAnalytics.cs
@@ -27,8 +27,8 @@ namespace Microsoft.DecisionService.Crawl
         internal static TextAnalyticRequest CreateRequestFromText(string text)
         {
             // Based on email thread with Arvind Krishnaa Jagannathan <arjagann@microsoft.com>
-            if (text.Length >= 10240 / 2)
-            text = text.Substring(0, 10240 / 2);
+            if (text.Length >= Constants.MaxRequestSizeUtf16)
+            text = text.Substring(0, Constants.MaxRequestSizeUtf16);
 
             return new TextAnalyticRequest
             {
@@ -62,8 +62,8 @@ namespace Microsoft.DecisionService.Crawl
                     var text = textBuilder.ToString();
 
                     // Based on email thread with Arvind Krishnaa Jagannathan <arjagann@microsoft.com>
-                    if (text.Length >= 10240 / 2)
-                        text = text.Substring(0, 10240 / 2);
+                    if (text.Length >= Constants.MaxRequestSizeUtf16)
+                        text = text.Substring(0, Constants.MaxRequestSizeUtf16);
 
                     return CreateRequestFromText(text);
                 },

--- a/Crawl/Constants.cs
+++ b/Crawl/Constants.cs
@@ -1,0 +1,22 @@
+//------------------------------------------------------------------------------
+// <copyright company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+using Newtonsoft.Json;
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.DecisionService.Crawl
+{
+    internal static class Constants
+    {
+        public const int MaxRequestSizeAnsi = 10240;
+        public const int MaxRequestSizeUtf16 = MaxRequestSizeAnsi / 2;
+    }
+}


### PR DESCRIPTION
Fix the Crawl pipeline's EntityLinking task, which breaks due to Cognitive Services discontinuing the individual endpoint for entity linking, merging it into Text Analytics.