### PR TITLE
Remove uploading of stdout/stderr, printing of customer sensitive data

### DIFF
--- a/DataScience/Experimentation.py
+++ b/DataScience/Experimentation.py
@@ -304,9 +304,6 @@ def main(args):
 
     print("\n***************************************")
     Logger.info("SETTINGS\n Base command + log file: {}\n".format(base_command) +
-                "Shared feature namespaces: {}\n".format(shared_features) +
-                "Action feature namespaces: {}\n".format(action_features) +
-                "Marginal feature namespaces: {}\n".format(marginal_features) +
                 'cb_types: ['+', '.join(args.cb_types) + ']\n' +
                 'learning rates: ['+', '.join(map(str,args.learning_rates)) + ']\n' +
                 'l1 regularization rates: ['+', '.join(map(str,args.regularizations)) + ']\n' +

--- a/DataScience/ExperimentationAzure.py
+++ b/DataScience/ExperimentationAzure.py
@@ -59,6 +59,7 @@ if __name__ == '__main__':
         task_dir = os.path.dirname(os.path.dirname(ld_args.log_dir))
   
         geneva_gbl_vals = {'appId': ld_args.app_id, 'jobId': main_args.evaluation_id}
+        
         Logger.create_loggers(geneva_namespace=main_args.geneva_namespace,
                               geneva_host=main_args.geneva_host,
                               geneva_port=main_args.geneva_port,
@@ -209,6 +210,4 @@ if __name__ == '__main__':
         Logger.info('Total Job time in seconds: {}'.format((end_time - start_time).seconds))
         sys.stdout.flush()
         sys.stderr.flush()
-        azure_util.upload_to_blob(ld_args.app_id, os.path.join(main_args.output_folder, 'stdout.txt'), os.path.join(task_dir, 'stdout.txt'))
-        azure_util.upload_to_blob(ld_args.app_id, os.path.join(main_args.output_folder, 'stderr.txt'), os.path.join(task_dir, 'stderr.txt'))
         Logger.close()

--- a/DataScience/loggers/logger_wrapper.py
+++ b/DataScience/loggers/logger_wrapper.py
@@ -11,7 +11,7 @@ class Logger:
     @classmethod
     def create_loggers(cls, **kwargs):
         cls.loggers.append(ConsoleLogger())
-        if "geneva_namespace" in kwargs:
+        if "geneva_namespace" in kwargs and kwargs["geneva_namespace"]:
             cls.loggers.append(GenevaLogger(namespace=kwargs["geneva_namespace"],
                                             host=kwargs["geneva_host"],
                                             port=kwargs["geneva_port"],


### PR DESCRIPTION
Uploading stdout/stderr to blob storage is no longer necessary. We've modified the job release task for evaluations to not delete all files in the job's workspace.