### PR TITLE
Added gzip mode 

### DIFF
--- a/DataScience/LogDownloader.py
+++ b/DataScience/LogDownloader.py
@@ -60,7 +60,7 @@ def add_parser_args(parser):
     4: never overwrite; append if the size is larger, without asking; skip currently used blobs''', default=0)
     parser.add_argument('--dry_run', help="print which blobs would have been downloaded, without downloading", action='store_true')
     parser.add_argument('--create_gzip_mode', type=int, help='''Mode to create gzip file(s) for Vowpal Wabbit:
-    0: create one gzip file for each LastConfigurationEditDate prefix
+    0: create one gzip file for each LastConfigurationEditDate prefix. Only run evaluation on oldest config folder.
     1: create a unique gzip file by merging over file dates. Only uses largest cooked log file per day
     2: create a unique gzip file by uniquing over EventId and sorting by Timestamp
     3: create a unique gzip file by merging over file dates. Uses all cooked log files per day''', default=-1)
@@ -291,10 +291,7 @@ def download_container(app_id, log_dir, container=None, conn_string=None, accoun
                     selected_fps_merged = []
                     last_fp_date = None
                     for fp in selected_fps:
-                        # has number after 
                         fp_date = datetime.datetime.strptime('_'.join(fp.split('_data_')[1].split('_')[:3]), "%Y_%m_%d")
-                        #check for dups accross config dates
-                        #get multiple from same day
                         if fp_date != last_fp_date:
                             selected_fps_merged.append(fp)
                             last_fp_date = fp_date
@@ -349,18 +346,6 @@ def download_container(app_id, log_dir, container=None, conn_string=None, accoun
 
                 elif create_gzip_mode == 3:
                     selected_fps.sort(key=lambda x : (list(map(int,x.split('_data_')[1].split('_')[:3])), -os.path.getsize(x), x))
-                    # selected_fps_merged = []
-                    # last_fp_date_with_file_number = None
-
-                    # for fp in selected_fps:
-                    #     #within a day cooked logs are split up onto 250 mb files 
-                    #     #we want to file all unique files within a given day
-                    #     #get the file date with file number _YYYY_MM_DD_#*.json
-                    #     fp_date_with_file_number = fp.split('_data_')[1][:-5]
-                    #     if fp_date_with_file_number != last_fp_date_with_file_number:
-                    #         selected_fps_merged.append(fp)
-                    #         last_fp_date_with_file_number = fp_date_with_file_number
-
                     start_date = '-'.join(selected_fps[0].split('_data_')[1].split('_')[:3])
                     end_date = '-'.join(selected_fps[-1].split('_data_')[1].split('_')[:3])
                     output_fp = os.path.join(log_dir, app_id, app_id+'_merged_data_'+start_date+'_'+end_date+'.json.gz')

--- a/DataScience/LogDownloader.py
+++ b/DataScience/LogDownloader.py
@@ -345,11 +345,11 @@ def download_container(app_id, log_dir, container=None, conn_string=None, accoun
                                 print()
 
                 elif create_gzip_mode == 3:
-                    selected_fps.sort(key=lambda x : (list(map(int,x.split('_data_')[1].split('_')[:3])), -os.path.getsize(x), x))
                     start_date = '-'.join(selected_fps[0].split('_data_')[1].split('_')[:3])
                     end_date = '-'.join(selected_fps[-1].split('_data_')[1].split('_')[:3])
                     output_fp = os.path.join(log_dir, app_id, app_id+'_merged_data_'+start_date+'_'+end_date+'.json.gz')
                     Logger.info('Merge and zip files of all LastConfigurationEditDate to: {}'.format(output_fp))
+
                     if not os.path.isfile(output_fp) or __name__ == '__main__' and input('Output file already exists. Do you want to overwrite [Y/n]? '.format(output_fp)) in {'Y', 'y'}:
                         if dry_run:
                             for fp in selected_fps:


### PR DESCRIPTION
GZIP modes:
0 -- run evaluation on all files in oldest config folder (that falls within the specified date range)
1 -- run evaluation on one file per day from all config folders within specified date range (does not work with the multiple 250 mb files per day change)
2 -- [irrelevant] takes the cooked log line with highest reward for each event ID
3 -- (new gzip mode that I am adding) run evaluations on all files from all config folders within specified date range. 


history of gzip modes:
gzip mode was 1 until cooked logs were changed to have multiple 250 mb files per day (only one file per day was being processed)
gzip mode was changed to 0 -- evaluations were only running on oldest configuration folder 