### PR TITLE
Ormichae/mergeconfigfolders

### DIFF
--- a/DataScience/CookedLogSequence.py
+++ b/DataScience/CookedLogSequence.py
@@ -62,3 +62,4 @@ class CookedLogSequence:
                 else:
                     Logger.info('duplicate file: {}'.format(fp))
         return CookedLogSequence(merged_files)
+        

--- a/DataScience/CookedLogSequence.py
+++ b/DataScience/CookedLogSequence.py
@@ -1,0 +1,64 @@
+from datetime import datetime
+from loggers import Logger
+import re
+
+class CookedLogSequence:
+    def __init__(self, files):
+        self.files = files
+
+    def get_file_start_time(self, fp):
+        with open(fp, 'r') as f:
+            first_line = f.readline()
+            return datetime.strptime(re.search('Timestamp":"(.*?)0Z', first_line).group(1), "%Y-%m-%dT%H:%M:%S.%f")
+            f.close()
+    
+    def get_file_end_time(self, fp):
+        with open(fp, 'r') as f:
+            last_line = f.readlines()[-1]
+            return datetime.strptime(re.search('Timestamp":"(.*?)0Z', last_line).group(1), "%Y-%m-%dT%H:%M:%S.%f")
+            f.close()
+    
+    def get_first_ts(self):
+        if (len(self.files) > 0):
+            return self.get_file_start_time(self.files[0])
+        return datetime.strptime('2000-01-01T00:00:00.000000', "%Y-%m-%dT%H:%M:%S.%f")
+    
+    def get_last_ts(self):
+        if (len(self.files) > 0):
+            return self.get_file_end_time(self.files[-1])
+        return datetime.strptime('2000-01-01T00:00:00.000000', "%Y-%m-%dT%H:%M:%S.%f")
+
+    #Merging of CookedLogSequence must be in sequential order
+    #Ex. We have three sequences in the following order A B C
+    #if we merge(A,C), B cannot later be merged
+    #we have to in sequential order merge(merge(A,B),C). 
+    def merge(self, other):
+        merged_files = self.files
+        merged_end_time = self.get_last_ts()
+        merge_remaining_files = other.get_first_ts() > merged_end_time
+        for fp in other.files:
+            if merge_remaining_files:
+                merged_files.append(fp)
+            else:
+                file_end_time = other.get_file_end_time(fp)
+                output_file_name = fp[0:-5] + '_non_overlapping.json'
+                if (file_end_time > merged_end_time):
+                    with open(output_file_name, 'w') as output_fp:
+                        lines = open(fp, 'r+').readlines()
+                        should_append = False
+                        Logger.info('partially overlapping file: {}'.format(fp))
+                        for line in lines:
+                            if(should_append):
+                                output_fp.write(line)
+                            else:
+                                cur_time = datetime.strptime(re.search('Timestamp":"(.*?)0Z', line).group(1), "%Y-%m-%dT%H:%M:%S.%f")
+                                if (cur_time > merged_end_time):
+                                    Logger.info('first non overlapping timestamp: {}'.format(cur_time))
+                                    output_fp.write(line)
+                                    should_append = True
+                                    merge_remaining_files = True
+                    output_fp.close()
+                    merged_files.append(output_file_name)
+                else:
+                    Logger.info('duplicate file: {}'.format(fp))
+        return CookedLogSequence(merged_files)

--- a/DataScience/CookedLogSequence.py
+++ b/DataScience/CookedLogSequence.py
@@ -62,4 +62,3 @@ class CookedLogSequence:
                 else:
                     Logger.info('duplicate file: {}'.format(fp))
         return CookedLogSequence(merged_files)
-        

--- a/DataScience/CookedLogSequence.py
+++ b/DataScience/CookedLogSequence.py
@@ -17,7 +17,6 @@ class CookedLogSequence:
             return self.get_time_from_log_line(first_line)
     
     def get_file_end_time(self, fp):
-
         with open(fp, 'r') as f:
             last_line = f.readlines()[-1]
             return self.get_time_from_log_line(last_line)
@@ -33,24 +32,26 @@ class CookedLogSequence:
         return datetime.min
     
     def find_first_file_to_merge(self, files, merged_end_time):
+        #optimization -- if the last file ends before merge_end_time then entire list of files contain duplicates
         if self.get_file_end_time(files[-1]) < merged_end_time:
-            return -1
+            return None
         candidate_index = len(files) - 1
         for i, fp in enumerate(files):
             if self.get_file_start_time(fp) > merged_end_time:
+                #first file that has no overlap
                 candidate_index = i
                 break
+        #check if file before candidate file has overlap (ie starts before merged_end_time and ends after)
         if candidate_index > 0 and self.get_file_end_time(files[candidate_index - 1]) > merged_end_time:
             return candidate_index - 1
         return candidate_index
 
-    def find_first_line_to_merge(self, fp, merged_end_time):
-        lines = open(fp, 'r').readlines()
+    def find_first_line_to_merge(self, lines, merged_end_time):
         for i, line in enumerate(lines):
             line_time = self.get_time_from_log_line(line)
             if line_time > merged_end_time:
                 return i
-        return -1
+        return None
 
     #Merging of CookedLogSequence must be in sequential order
     #Ex. We have three sequences in the following order A B C
@@ -60,20 +61,22 @@ class CookedLogSequence:
         merged_files = list(self.files)
         merged_end_time = self.get_last_ts()
         overlapping_file_index = self.find_first_file_to_merge(other.files, merged_end_time)
-        if overlapping_file_index > -1:
+        if overlapping_file_index != None:
             merge_fp = other.files[overlapping_file_index]
-            first_line_to_append = self.find_first_line_to_merge(merge_fp, merged_end_time)
-            if(first_line_to_append == 0):
-                merged_files.extend(other.files[overlapping_file_index:])
-            else:
+            with open(merge_fp, 'r') as merge:
+                lines = merge.readlines()
+            first_line_to_append = self.find_first_line_to_merge(lines, merged_end_time)
+            if first_line_to_append == 0:
+                #merge entire file
+                merged_files.append(merge_fp)
+            elif first_line_to_append != None:
                 Logger.info('partially overlapping file: {}'.format(merge_fp))
                 output_fp = os.path.splitext(merge_fp)[0] + '_non_overlapping.json'
+                #create new file starting at the first_line_to_append to the end of the file.
                 with open(output_fp, 'w') as output_file:
-                    lines = open(merge_fp, 'r').readlines()
                     output_file.writelines(lines[first_line_to_append:])
-                output_file.close()
                 merged_files.append(output_fp)
-                merged_files.extend(other.files[overlapping_file_index + 1:])
+            merged_files.extend(other.files[overlapping_file_index + 1:])
         else:
             Logger.info('duplicate files: {}'.format(other.files))
 

--- a/DataScience/CookedLogSequence.py
+++ b/DataScience/CookedLogSequence.py
@@ -1,66 +1,80 @@
 from datetime import datetime
 from loggers import Logger
-import re
+import re, os
 
 class CookedLogSequence:
     timestamp_format = '%Y-%m-%dT%H:%M:%S.%f'
     timestamp_pattern = r'[^\\]"Timestamp"\s*:\s*"(.*?)0Z"'
     def __init__(self, files):
         self.files = files
+    
+    def get_time_from_log_line(self, log_line):
+        return datetime.strptime(re.search(self.timestamp_pattern, log_line).group(1), self.timestamp_format)
 
     def get_file_start_time(self, fp):
         with open(fp, 'r') as f:
             first_line = f.readline()
-            return datetime.strptime(re.search(self.timestamp_pattern, first_line).group(1), self.timestamp_format)
-            f.close()
+            return self.get_time_from_log_line(first_line)
     
     def get_file_end_time(self, fp):
+
         with open(fp, 'r') as f:
             last_line = f.readlines()[-1]
-            return datetime.strptime(re.search(self.timestamp_pattern, last_line).group(1), self.timestamp_format)
-            f.close()
+            return self.get_time_from_log_line(last_line)
     
     def get_first_ts(self):
-        if (len(self.files) > 0):
+        if len(self.files) > 0:
             return self.get_file_start_time(self.files[0])
         return datetime.min
     
     def get_last_ts(self):
-        if (len(self.files) > 0):
+        if len(self.files) > 0:
             return self.get_file_end_time(self.files[-1])
         return datetime.min
+    
+    def find_first_file_to_merge(self, files, merged_end_time):
+        if self.get_file_end_time(files[-1]) < merged_end_time:
+            return -1
+        candidate_index = len(files) - 1
+        for i, fp in enumerate(files):
+            if self.get_file_start_time(fp) > merged_end_time:
+                candidate_index = i
+                break
+        if candidate_index > 0 and self.get_file_end_time(files[candidate_index - 1]) > merged_end_time:
+            return candidate_index - 1
+        return candidate_index
+
+    def find_first_line_to_merge(self, fp, merged_end_time):
+        lines = open(fp, 'r').readlines()
+        for i, line in enumerate(lines):
+            line_time = self.get_time_from_log_line(line)
+            if line_time > merged_end_time:
+                return i
+        return -1
 
     #Merging of CookedLogSequence must be in sequential order
     #Ex. We have three sequences in the following order A B C
     #if we merge(A,C), B cannot later be merged
     #we have to in sequential order merge(merge(A,B),C). 
     def merge(self, other):
-        merged_files = self.files
+        merged_files = list(self.files)
         merged_end_time = self.get_last_ts()
-        merge_remaining_files = other.get_first_ts() > merged_end_time
-        for fp in other.files:
-            if merge_remaining_files:
-                merged_files.append(fp)
+        overlapping_file_index = self.find_first_file_to_merge(other.files, merged_end_time)
+        if overlapping_file_index > -1:
+            merge_fp = other.files[overlapping_file_index]
+            first_line_to_append = self.find_first_line_to_merge(merge_fp, merged_end_time)
+            if(first_line_to_append == 0):
+                merged_files.extend(other.files[overlapping_file_index:])
             else:
-                file_end_time = other.get_file_end_time(fp)
-                output_file_name = fp[0:-5] + '_non_overlapping.json'
-                if (file_end_time > merged_end_time):
-                    with open(output_file_name, 'w') as output_fp:
-                        lines = open(fp, 'r+').readlines()
-                        should_append = False
-                        Logger.info('partially overlapping file: {}'.format(fp))
-                        for line in lines:
-                            if(should_append):
-                                output_fp.write(line)
-                            else:
-                                cur_time = datetime.strptime(re.search(self.timestamp_pattern, line).group(1), self.timestamp_format)
-                                if (cur_time > merged_end_time):
-                                    Logger.info('first non overlapping timestamp: {}'.format(cur_time))
-                                    output_fp.write(line)
-                                    should_append = True
-                                    merge_remaining_files = True
-                    output_fp.close()
-                    merged_files.append(output_file_name)
-                else:
-                    Logger.info('duplicate file: {}'.format(fp))
+                Logger.info('partially overlapping file: {}'.format(merge_fp))
+                output_fp = os.path.splitext(merge_fp)[0] + '_non_overlapping.json'
+                with open(output_fp, 'w') as output_file:
+                    lines = open(merge_fp, 'r').readlines()
+                    output_file.writelines(lines[first_line_to_append:])
+                output_file.close()
+                merged_files.append(output_fp)
+                merged_files.extend(other.files[overlapping_file_index + 1:])
+        else:
+            Logger.info('duplicate files: {}'.format(other.files))
+
         return CookedLogSequence(merged_files)

--- a/DataScience/LogDownloader.py
+++ b/DataScience/LogDownloader.py
@@ -173,7 +173,6 @@ def download_container(app_id, log_dir, container=None, conn_string=None, accoun
                     Logger.info('{} - Skip: imitation mode detected for configuration.\n'.format(blob.name))
                 continue
             
-            print(blob.name)
             blob_day = datetime.datetime.strptime(blob.name.split('/data/', 1)[1].split('_', 1)[0], '%Y/%m/%d')
             if (start_date and blob_day < start_date) or (end_date and end_date < blob_day):
                 if verbose:
@@ -371,7 +370,7 @@ def download_container(app_id, log_dir, container=None, conn_string=None, accoun
 
                     if not os.path.isfile(output_fp) or __name__ == '__main__' and input('Output file already exists. Do you want to overwrite [Y/n]? '.format(output_fp)) in {'Y', 'y'}:
                         if dry_run:
-                            for fp in selected_fps:
+                            for fp in merged_configs.files:
                                 Logger.info('Adding: {}'.format(fp))
                             Logger.info('--dry_run - Not downloading!')
                         else:

--- a/DataScience/LogDownloader.py
+++ b/DataScience/LogDownloader.py
@@ -1,4 +1,5 @@
 import sys
+from collections import OrderedDict
 from functools import reduce
 from loggers import Logger
 from CookedLogSequence import CookedLogSequence
@@ -358,8 +359,12 @@ def download_container(app_id, log_dir, container=None, conn_string=None, accoun
 
                 elif create_gzip_mode == 3:
                     selected_fps.sort(key=lambda fp : (get_config_date_from_fp(fp), get_file_day_from_fp(fp), get_file_number_from_fp(fp)))
-                    
-                    merged_configs = reduce(lambda sequence, fp: sequence.merge(CookedLogSequence([fp])), selected_fps, CookedLogSequence([]))
+
+                    configs = OrderedDict()
+                    for fp in selected_fps:
+                        configs.setdefault(os.path.basename(fp).split('_data_',1)[0], []).append(fp)
+
+                    merged_configs = reduce(lambda sequence, config: sequence.merge(CookedLogSequence(configs[config])), configs, CookedLogSequence([]))
                     
                     start_date = '-'.join(merged_configs.files[0].split('_data_')[1].split('_')[:3])
                     end_date = '-'.join(merged_configs.files[-1].split('_data_')[1].split('_')[:3])


### PR DESCRIPTION
Background:
-	A while back we stated writing cooked logs to 250 mb files instead of one large file per day. 
-	Before this change we were running evaluations with gzip_mode = 1 (uses largest file per day per configuration folder)
-	After splitting up the cooked logs into 250 mb files, this gzip_mode caused us to skip a large portion of data for each day so we switched to gzip_mode = 0 (turns out this only runs on data from the oldest config folder)

With Auto-optimization, every time the auto-optimization pipeline runs, a new config file will be created and the model will be carried over to the new config folder, so we will not be retraining on 2 days worth of data but we will have files with the same name in different config folders. 

I added a gzip_mode = 3 which runs evaluations on non duplicate data from all files in all configuration folders.  


