### PR TITLE
fixed cooked log sorting across months

### DIFF
--- a/DataScience/CookedLogSequence.py
+++ b/DataScience/CookedLogSequence.py
@@ -45,7 +45,7 @@ class CookedLogSequence:
                 #first file that has no overlap
                 candidate_index = i
                 break
-        #check if the file before candidate file has an averlap with the merged files (ie starts before merged_end_time and ends after)
+        #check if the file before candidate file has an overlap with the merged files (ie starts before merged_end_time and ends after)
         if candidate_index > 0 and CookedLogSequence.__get_file_end_time(files[candidate_index - 1]) > merged_end_time:
             return candidate_index - 1
         return candidate_index

--- a/DataScience/LogDownloader.py
+++ b/DataScience/LogDownloader.py
@@ -29,6 +29,12 @@ def valid_date(s):
 def get_config_date_from_fp(fp):
     return datetime.datetime.strptime(os.path.basename(fp).split('_data_',1)[0], "%Y%m%d%H%M%S")
 
+def get_file_year_from_fp(fp):
+    return int(os.path.basename(fp).split('_data_')[1].split('_')[0])
+
+def get_file_month_from_fp(fp):
+    return int(os.path.basename(fp).split('_data_')[1].split('_')[1])
+
 def get_file_day_from_fp(fp):
     return int(os.path.basename(fp).split('_data_')[1].split('_')[2])
 
@@ -358,7 +364,7 @@ def download_container(app_id, log_dir, container=None, conn_string=None, accoun
                                 print()
 
                 elif create_gzip_mode == 3:
-                    selected_fps.sort(key=lambda fp : (get_config_date_from_fp(fp), get_file_day_from_fp(fp), get_file_number_from_fp(fp)))
+                    selected_fps.sort(key=lambda fp : (get_config_date_from_fp(fp), get_file_year_from_fp(fp), get_file_month_from_fp(fp), get_file_day_from_fp(fp), get_file_number_from_fp(fp)))
 
                     configs = OrderedDict()
                     for fp in selected_fps:


### PR DESCRIPTION
Cooked log sorting was being done based on the day. This PR addresses sorting across months and years as well