### PR TITLE
Feature importance, disable auto save_resume using --predict_only_model flag

### DIFF
--- a/DataScience/FeatureImportance.py
+++ b/DataScience/FeatureImportance.py
@@ -106,7 +106,7 @@ def get_feature_importance(log_file, ml_args, warmstart_model=None, min_num_feat
     else:
         l1 = 1e-7
 
-    vw_base = 'vw ' + ml_args + ' --dsjson --data {0} --quiet'.format(log_file)
+    vw_base = 'vw --predict_only_model ' + ml_args + ' --dsjson --data {0} --quiet'.format(log_file)
     if warmstart_model:
         vw_base += ' -i {0}'.format(warmstart_model)
 


### PR DESCRIPTION
With the latest vw update, save_resume is enabled by default which breaks feature importances, since the flag is different and all features are always displayed at different regularization values for readable models.

--predict_only_model turns this flag off. Affects only readable models.

Reference PR
https://msazure.visualstudio.com/One/_git/AIR-MSRAI-VowpalWabbit/pullrequest/5629848